### PR TITLE
Add initial implementation of bruh as a docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM dock0/arch
+
+VOLUME ["/config", "/data"]
+EXPOSE 22 9001 9890 9891
+
+RUN echo 'Server = http://mirrors.acm.wpi.edu/archlinux/$repo/os/$arch' > /etc/pacman.d/mirrorlist
+RUN pacman --noconfirm -Sy ghc cabal-install pkg-config zeromq python python-virtualenv supervisor redis openssh
+ADD . /bruh
+RUN /bruh/docker/bootstrap.sh
+
+CMD /bruh/docker/run.sh

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# This script is run during container build to get the environment
+# bootstrapped.
+
+set -e
+
+# Get and build walnut
+git clone https://github.com/reisen/walnut.git /walnut
+cd /walnut
+cabal sandbox init
+cabal update
+cabal install --only-dependencies
+ln -s /config/config /walnut
+ln -s /walnut/drivers /bruh
+
+# Install bruh deps
+cd /bruh
+virtualenv env
+(. env/bin/activate && pip install -r requirements.txt &&
+                       pip install pyhyphen)
+
+# Add bruh user
+useradd bruh --home=/bruh --shell=/bin/bash
+echo bruh:bruh | chpasswd
+chown -R bruh:bruh /bruh /walnut
+
+# Generate host keys
+ssh-keygen -N '' -t dsa -f /etc/ssh/ssh_host_dsa_key
+ssh-keygen -N '' -t rsa -f /etc/ssh/ssh_host_rsa_key
+sed -i /etc/ssh/sshd_config -e 's/^UsePAM .*/UsePAM no/'

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+supervisord -c /bruh/docker/supervisord.conf
+
+while :
+do
+    echo "Starting supervisorctl ..."
+    supervisorctl -c /bruh/docker/supervisord.conf
+done

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,32 @@
+[supervisord]
+# Use defaults, but supervisord won't run without this section
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=http://localhost:9001
+prompt=bruh
+
+[inet_http_server]
+port=:9001
+
+[program:walnut]
+directory=/walnut
+command=cabal run
+user=bruh
+
+[program:bruh]
+directory=/bruh
+environment=LANG=en_US.utf8
+command=sh -c '. env/bin/activate && python bruh.py'
+user=bruh
+
+[program:redis]
+directory=/data
+command=redis-server
+user=redis
+
+[program:sshd]
+command=/sbin/sshd -D
+autostart=false


### PR DESCRIPTION
This is an initial version of Bruh running in a docker container.  To build:

docker build -t reisen/bruh .

and to run:

docker run --name=bruh -p 2222:22 -p 9001:9001 -v ~/bruh-config:/config -v ~/bruh-data:/data -t -i --rm reisen/bruh 

In this example, ~/bruh-config contains the config file, and ~/bruh-data is where redis will save its data (it must be writable by redis user in the container, I used mode 777 for now).  This will run bruh in the foreground and drop you into a supervisorctl shell.  If you want actual shell access, you can run "start sshd" to spin up sshd and then "ssh -p 2222 bruh@localhost", password is also bruh.

To stop the container, run:

docker stop bruh

Once you are happy with it, then you ca run it in the background:

docker run --name=bruh -p 2222:22 -p 9001:9001 -v ~/bruh-config:/config -v ~/bruh-data:/data -d reisen/bruh

Supervisord web interface is available at http://localhost:9001/