### PR TITLE
Update Docker to run with latest changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ VOLUME ["/config", "/data"]
 EXPOSE 22 9001 9890 9891
 
 RUN echo 'Server = http://mirrors.acm.wpi.edu/archlinux/$repo/os/$arch' > /etc/pacman.d/mirrorlist
-RUN pacman --noconfirm -Sy ghc cabal-install pkg-config zeromq python python-virtualenv supervisor redis openssh
+RUN pacman --noconfirm -Sy ghc cabal-install pkg-config zeromq python python-virtualenv supervisor redis make
 ADD . /bruh
 RUN /bruh/docker/bootstrap.sh
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
 supervisord -c /bruh/docker/supervisord.conf
-
-while :
-do
-    echo "Starting supervisorctl ..."
-    supervisorctl -c /bruh/docker/supervisord.conf
-done
+echo "Starting supervisorctl ..."
+exec supervisorctl -c /bruh/docker/supervisord.conf

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -13,6 +13,7 @@ port=:9001
 
 [program:walnut]
 directory=/walnut
+environment=HOME=/bruh
 command=cabal run
 user=bruh
 
@@ -21,12 +22,3 @@ directory=/bruh
 environment=LANG=en_US.utf8
 command=sh -c '. env/bin/activate && python bruh.py'
 user=bruh
-
-[program:redis]
-directory=/data
-command=redis-server
-user=redis
-
-[program:sshd]
-command=/sbin/sshd -D
-autostart=false

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -20,5 +20,5 @@ user=bruh
 [program:bruh]
 directory=/bruh
 environment=LANG=en_US.utf8
-command=sh -c '. env/bin/activate && python bruh.py'
+command=sh -c '. env/bin/activate && python bruh.py -d /data/data.rdb'
 user=bruh


### PR DESCRIPTION
This commit provides some maintenance for bits that shifted around
in walnut and bruh as well as some fixes for things that broke
externally (e.g. pip). Noticeable changes include:

 - sshd is removed since modern docker can exec directly
 - redis is no longer launched by supervisord (redislite does it)
 - the run.sh script is no longer an infinite loop